### PR TITLE
Add support for Twig tilde whitespace control character

### DIFF
--- a/grammar/liquid-html.ohm
+++ b/grammar/liquid-html.ohm
@@ -32,7 +32,8 @@ Helpers {
 Liquid <: Helpers {
   Node := (liquidNode | TextNode)*
   openControl := "{{" | "{%"
-  endOfTagName = &("-%}" | "-}}" | "%}" | "}}")
+  endOfTagName = &("-%}" | "-}}" | "~%}" | "~}}" | "%}" | "}}")
+  whitespaceControl = "-" | "~"
   endOfVarName = ~identifierCharacter
   endOfIdentifier = endOfTagName | endOfVarName
 
@@ -82,13 +83,13 @@ Liquid <: Helpers {
     | liquidTagOpenStrict
     | liquidTagOpenBaseCase
 
-  liquidTagClose = "{%" "-"? space* "end" blockName space* tagMarkup "-"? "%}"
+  liquidTagClose = "{%" whitespaceControl? space* "end" blockName space* tagMarkup whitespaceControl? "%}"
 
   // These two are the same but transformed differently
   liquidTagRule<name, markup> =
-    "{%" "-"? space* (name endOfIdentifier) space* markup "-"? "%}"
+    "{%" whitespaceControl? space* (name endOfIdentifier) space* markup whitespaceControl? "%}"
   liquidTagOpenRule<name, markup> =
-    "{%" "-"? space* (name endOfIdentifier) space* markup "-"? "%}"
+    "{%" whitespaceControl? space* (name endOfIdentifier) space* markup whitespaceControl? "%}"
 
   liquidTagBaseCase = liquidTagRule<liquidTagName, tagMarkup>
 
@@ -182,10 +183,10 @@ Liquid <: Helpers {
   liquidTagOpenPaginateMarkup =
     liquidExpression space+ "by" space+ liquidExpression argumentSeparatorOptionalComma tagArguments space*
 
-  liquidDrop = "{{" "-"? space* liquidDropCases "-"? "}}"
+  liquidDrop = "{{" whitespaceControl? space* liquidDropCases whitespaceControl? "}}"
   liquidDropCases = liquidVariable | liquidDropBaseCase
-  liquidDropBaseCase = anyExceptStar<("-}}" | "}}")>
-  liquidInlineComment = "{#" "-"? space? twigTagMarkup "-"? "#}"
+  liquidDropBaseCase = anyExceptStar<("-}}" | "~}}" | "}}")>
+  liquidInlineComment = "{#" whitespaceControl? space? twigTagMarkup whitespaceControl? "#}"
 
   liquidRawTag =
     | liquidRawTagImpl<"raw">
@@ -194,18 +195,18 @@ Liquid <: Helpers {
     | liquidRawTagImpl<"stylesheet">
     | liquidRawTagImpl<"style">
   liquidRawTagImpl<name> =
-    "{%" "-"? space* (name endOfIdentifier) space* tagMarkup "-"? "%}"
+    "{%" whitespaceControl? space* (name endOfIdentifier) space* tagMarkup whitespaceControl? "%}"
     anyExceptStar<liquidRawTagClose<name>>
-    "{%" "-"? space* "end" (name endOfIdentifier) space* "-"? "%}"
+    "{%" whitespaceControl? space* "end" (name endOfIdentifier) space* whitespaceControl? "%}"
   liquidRawTagClose<name> =
-    "{%" "-"? space* "end" (name endOfIdentifier) space* "-"? "%}"
+    "{%" whitespaceControl? space* "end" (name endOfIdentifier) space* whitespaceControl? "%}"
 
   liquidBlockComment =
     commentBlockStart
       (liquidBlockComment | anyExceptPlus<(commentBlockStart | commentBlockEnd)>)*
     commentBlockEnd
-  commentBlockStart = "{%" "-"? space* ("comment"    endOfIdentifier) space* tagMarkup "-"? "%}"
-  commentBlockEnd   = "{%" "-"? space* ("endcomment" endOfIdentifier) space* tagMarkup "-"? "%}"
+  commentBlockStart = "{%" whitespaceControl? space* ("comment"    endOfIdentifier) space* tagMarkup whitespaceControl? "%}"
+  commentBlockEnd   = "{%" whitespaceControl? space* ("endcomment" endOfIdentifier) space* tagMarkup whitespaceControl? "%}"
 
   // In order for the grammar to "fallback" to the base case, this
   // rule must pass if and only if we support what we parse. This
@@ -215,7 +216,7 @@ Liquid <: Helpers {
   // instead of falling back to the other rule:
   // {{ 'string' | some_filter }}
   liquidVariable = liquidExpression liquidFilter* space* &liquidStatementEnd
-  liquidStatementEnd = ("-}}" | "}}" | "-%}" | "%}")
+  liquidStatementEnd = ("-}}" | "~}}" | "}}" | "-%}" | "~%}" | "%}")
 
   liquidExpression =
     | liquidString
@@ -266,8 +267,8 @@ Liquid <: Helpers {
   variableSegmentAsLookup = variableSegment
   identifier = variableSegment "?"?
 
-  tagMarkup = anyExceptStar<("-%}"| "%}")>
-  twigTagMarkup = anyExceptStar<("-#}"| "#}")>
+  tagMarkup = anyExceptStar<("-%}"| "~%}" | "%}")>
+  twigTagMarkup = anyExceptStar<("-#}"| "~#}" | "#}")>
 
   liquidTagName =
     letter (alnum | "_")*

--- a/src/parser/stage-1-cst.ts
+++ b/src/parser/stage-1-cst.ts
@@ -174,8 +174,8 @@ export type ConcreteLiquidNode =
   | ConcreteLiquidDrop;
 
 interface ConcreteBasicLiquidNode<T> extends ConcreteBasicNode<T> {
-  whitespaceStart: null | '-';
-  whitespaceEnd: null | '-';
+  whitespaceStart: null | '-' | '~';
+  whitespaceEnd: null | '-' | '~';
 }
 
 export interface ConcreteLiquidRawTag
@@ -183,8 +183,8 @@ export interface ConcreteLiquidRawTag
   name: string;
   body: string;
   markup: string;
-  delimiterWhitespaceStart: null | '-';
-  delimiterWhitespaceEnd: null | '-';
+  delimiterWhitespaceStart: null | '-' | '~';
+  delimiterWhitespaceEnd: null | '-' | '~';
   blockStartLocStart: number;
   blockStartLocEnd: number;
   blockEndLocStart: number;

--- a/src/parser/stage-2-ast.ts
+++ b/src/parser/stage-2-ast.ts
@@ -174,10 +174,10 @@ export interface LiquidRawTag extends ASTNode<NodeTypes.LiquidRawTag> {
    * String body of the tag. So we don't try to parse it.
    */
   body: RawMarkup;
-  whitespaceStart: '-' | '';
-  whitespaceEnd: '-' | '';
-  delimiterWhitespaceStart: '-' | '';
-  delimiterWhitespaceEnd: '-' | '';
+  whitespaceStart: '-' | '~' | '';
+  whitespaceEnd: '-' | '~' | '';
+  delimiterWhitespaceStart: '-' | '~' | '';
+  delimiterWhitespaceEnd: '-' | '~' | '';
   blockStartPosition: Position;
   blockEndPosition: Position;
 }
@@ -216,10 +216,10 @@ export interface LiquidTagNode<Name, Markup>
    */
   markup: Markup;
   children?: LiquidHtmlNode[];
-  whitespaceStart: '-' | '';
-  whitespaceEnd: '-' | '';
-  delimiterWhitespaceStart?: '-' | '';
-  delimiterWhitespaceEnd?: '-' | '';
+  whitespaceStart: '-' | '~' | '';
+  whitespaceEnd: '-' | '~' | '';
+  delimiterWhitespaceStart?: '-' | '~' | '';
+  delimiterWhitespaceEnd?: '-' | '~' | '';
   blockStartPosition: Position;
   blockEndPosition?: Position;
 }
@@ -354,8 +354,8 @@ interface LiquidBranchNode<Name, Markup>
    */
   markup: Markup;
   children: LiquidHtmlNode[];
-  whitespaceStart: '-' | '';
-  whitespaceEnd: '-' | '';
+  whitespaceStart: '-' | '~' | '';
+  whitespaceEnd: '-' | '~' | '';
   blockStartPosition: Position;
 }
 
@@ -368,8 +368,8 @@ export interface LiquidDrop extends ASTNode<NodeTypes.LiquidDrop> {
    * The body of the drop. May contain filters. Not trimmed.
    */
   markup: string | LiquidVariable;
-  whitespaceStart: '-' | '';
-  whitespaceEnd: '-' | '';
+  whitespaceStart: '-' | '~' | '';
+  whitespaceEnd: '-' | '~' | '';
 }
 
 interface LiquidVariable extends ASTNode<NodeTypes.LiquidVariable> {

--- a/src/printer/utils/index.ts
+++ b/src/printer/utils/index.ts
@@ -34,8 +34,14 @@ export function getWhitespaceTrim(
   needsWhitespaceStrippingOnBreak: boolean | undefined,
   groupIds?: symbol | symbol[],
 ): Doc {
+  // Preserve an explicit '~' (Twig line-trim modifier) — only inject '-' when
+  // the user didn't already write a whitespace control character.
+  const onBreak =
+    needsWhitespaceStrippingOnBreak && !currWhitespaceTrim
+      ? '-'
+      : currWhitespaceTrim;
   return ifBreakChain(
-    needsWhitespaceStrippingOnBreak ? '-' : currWhitespaceTrim,
+    onBreak,
     currWhitespaceTrim,
     Array.isArray(groupIds) ? groupIds : [groupIds],
   );

--- a/test/twig-line-trim-tilde/fixed.liquid
+++ b/test/twig-line-trim-tilde/fixed.liquid
@@ -1,0 +1,20 @@
+It should preserve the ~ line-trim modifier on the left of a drop
+<div>{{~ some_var }}</div>
+
+It should preserve the ~ line-trim modifier on the right of a drop
+<div>{{ some_var ~}}</div>
+
+It should preserve the ~ line-trim modifier on both sides of a drop
+<div>{{~ some_var ~}}</div>
+
+It should preserve mixed - and ~ trim modifiers on a drop
+<div>
+  {{- some_var ~}}
+  {{~ other -}}
+</div>
+
+It should preserve the ~ line-trim modifier on tags
+{%~ if foo ~%}bar{%~ endif ~%}
+
+It should preserve mixed - and ~ trim modifiers on tags
+{%- if foo ~%}bar{%~ endif -%}

--- a/test/twig-line-trim-tilde/index.liquid
+++ b/test/twig-line-trim-tilde/index.liquid
@@ -1,0 +1,17 @@
+It should preserve the ~ line-trim modifier on the left of a drop
+<div>{{~ some_var }}</div>
+
+It should preserve the ~ line-trim modifier on the right of a drop
+<div>{{ some_var ~}}</div>
+
+It should preserve the ~ line-trim modifier on both sides of a drop
+<div>{{~ some_var ~}}</div>
+
+It should preserve mixed - and ~ trim modifiers on a drop
+<div>{{- some_var ~}}{{~ other -}}</div>
+
+It should preserve the ~ line-trim modifier on tags
+{%~ if foo ~%}bar{%~ endif ~%}
+
+It should preserve mixed - and ~ trim modifiers on tags
+{%- if foo ~%}bar{%~ endif -%}

--- a/test/twig-line-trim-tilde/index.spec.ts
+++ b/test/twig-line-trim-tilde/index.spec.ts
@@ -1,0 +1,6 @@
+import { assertFormattedEqualsFixed } from '../test-helpers';
+import * as path from 'path';
+
+describe(`Unit: ${path.basename(__dirname)}`, () => {
+  assertFormattedEqualsFixed(__dirname);
+});


### PR DESCRIPTION
This pull request adds support for the [Twig-style `~` (tilde) line-trim modifier.](https://twig.symfony.com/doc/3.x/templates.html#whitespace-control)

It updates the grammar, parser types, and printer logic to recognize and preserve both `-` and `~` as valid whitespace control characters, ensuring that templates using `~` for whitespace trimming are handled correctly.

Before this PR, the following Twig code:

```twig
{{~ some_var }}
```

Was prettified to:

```twig
{{ ~ some_var }}
```

Causing a Twig syntax error.

**Grammar and Parsing Enhancements:**

* Updated the `liquid-html.ohm` grammar to recognize `~` as a valid whitespace control character alongside `-`, including all relevant tag and drop rules, and token end conditions.

**Printer Logic Update:**

* Modified `getWhitespaceTrim` in `src/printer/utils/index.ts` to preserve an explicit `~` and only inject `-` if no whitespace control character was provided by the user.